### PR TITLE
Use same audit command for resolution

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -30,7 +30,7 @@ echo fixes and they do not apply to production, you may ignore them.
 echo
 echo To ignore these vulnerabilities, run:
 echo
-echo "yarn audit --json | grep auditAdvisory > .yarn-audit-known-issues"
+echo "yarn audit --json --groups dependencies | grep auditAdvisory > .yarn-audit-known-issues"
 echo
 echo and commit the yarn-audit-known-issues file.
 echo


### PR DESCRIPTION
In commit https://github.com/commonlit/yarn-audit-action2/commit/71d58a2a0cf5b67ce73702af05a13ee43409b3f2 we updated the actual audit command to add `--groups dependencies` so that it only audits production dependencies. We didn't update the resolution instructions, so in https://github.com/commonlit/commonlit/pull/24998 when I tried to add vulnerabilities to the ignore list I ended up with a much larger diff than I expected.

This PR updates the copy-pastable instructions so that the results align closer to what you would expect from reading the output of the action.